### PR TITLE
fix/ use import.meta.env.BASE_URL to load model correctly

### DIFF
--- a/src/3DModel/3DModel.ts
+++ b/src/3DModel/3DModel.ts
@@ -132,7 +132,7 @@ function createDuckModelConfig({ map, debug }: { map: Map, debug?: boolean }): I
       }
 
       new GLTFLoader()
-        .setPath('/models/rubber_duck/')
+        .setPath(`${import.meta.env.BASE_URL}/models/rubber_duck/`)
         .load(
           'scene.gltf',
           (object) => {


### PR DESCRIPTION
fix(3DModel): implement `import.meta.env.BASE_URL` to load model corrrectly on GH pages